### PR TITLE
fix: WB-3246, check locale validity before formatting a localized date

### DIFF
--- a/projects/ngx-ode-ui/src/lib/pipes/localizedDate.pipe.ts
+++ b/projects/ngx-ode-ui/src/lib/pipes/localizedDate.pipe.ts
@@ -1,4 +1,4 @@
-import {DatePipe} from '@angular/common';
+import {DatePipe, getLocaleId} from '@angular/common';
 import {Pipe, PipeTransform} from '@angular/core';
 import {BundlesService} from 'ngx-ode-sijil';
 
@@ -11,9 +11,20 @@ export class LocalizedDatePipe implements PipeTransform {
   constructor(private bundlesService: BundlesService) {
   }
 
-  transform(value: any, pattern: string = 'mediumDate'): any {
-    const datePipe: DatePipe = new DatePipe(this.bundlesService.currentLanguage);
+  transform(value: any, pattern: string = "mediumDate"): any {
+    let targetLanguage = this.bundlesService.currentLanguage || "en";
+    try {
+      // If targetLanguage and angular current locale are different, fall back angular locale to "en"
+      if (getLocaleId(targetLanguage) !== targetLanguage) {
+        targetLanguage = "en";
+      }
+    } catch (e) {
+      // getLocaleId(targetLanguage) can throw an error when locale is not recognized
+      // In such a case, fall back to "en"
+      targetLanguage = "en";
+    }
+    // Use angular locale formatting for localized dates
+    const datePipe: DatePipe = new DatePipe(targetLanguage);
     return datePipe.transform(value, pattern);
   }
-
 }


### PR DESCRIPTION
Formatting a date needs angular DatePipe, so we must be sure that the locale exists in angular before using the pipe.

[Ticket WB-3246](https://edifice-community.atlassian.net/browse/WB-3246)